### PR TITLE
Bug fix & fix compiler warnings

### DIFF
--- a/Src/file_ex.c
+++ b/Src/file_ex.c
@@ -5,7 +5,7 @@ size_t GetFileSize(FILE* fp) {
     return 0;
   }
 
-  uint64_t fileSize = ftell(fp);
+  int64_t fileSize = ftell(fp);
   if (fileSize < 0) {
     fileSize = 0;
   }

--- a/Src/ips.c
+++ b/Src/ips.c
@@ -5,14 +5,14 @@ bool IPS_HeaderValid(const SizedPtr_t* patch) {
     return false;
   }
 
-  return strncmp(patch->data, IPS_HEADER, 5) == 0;
+  return memcmp(patch->data, IPS_HEADER, 5) == 0;
 }
 
 bool IPS_IsEOF(const SizedPtr_t* patch, size_t* offset) {
   if (*offset + 3 > patch->size) {
     return true;
   }
-  return strncmp(patch->data + *offset, IPS_EOF, 3) == 0;
+  return memcmp(patch->data + *offset, IPS_EOF, 3) == 0;
 }
 
 bool IPS_ReadRecord(const SizedPtr_t* patch, IPS_Record_t* record, size_t* offset) {

--- a/Src/main.c
+++ b/Src/main.c
@@ -9,8 +9,8 @@ int main() {
   SizedPtr_t patch = ReadToEnd(PATCH_FILE, "rb");
   SizedPtr_t rom = ReadToEnd(ROM_FILE, "rb");
 
-  printf("Opened patch file (%d bytes)\n", patch.size);
-  printf("Opened rom file (%d bytes)\n", rom.size);
+  printf("Opened patch file (%ld bytes)\n", patch.size);
+  printf("Opened rom file (%ld bytes)\n", rom.size);
 
   if (!IPS_HeaderValid(&patch)) {
     printf("Header invalid, exiting.\n");
@@ -22,14 +22,14 @@ int main() {
   size_t lastWrittenOffset = 0;
   IPS_Record_t* record = malloc(sizeof(IPS_Record_t));
   size_t recordsRead = IPS_ReadRecords(&patch, record, &offset, &lastWrittenOffset);
-  printf("Read %d records from the patch file\n", recordsRead);
+  printf("Read %ld records from the patch file\n", recordsRead);
 
 
   size_t targetSize = rom.size;
   if (lastWrittenOffset + 1 > rom.size) {
     targetSize = lastWrittenOffset + 1;
   }
-  printf("Creating a patched rom of size %d bytes\n", targetSize);
+  printf("Creating a patched rom of size %ld bytes\n", targetSize);
 
   uint8_t* target = malloc(targetSize);
   memcpy(target, rom.data, rom.size);

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ mkdir -p obj
 mkdir -p bin
 
 LINK_FLAGS=""
-COMPILER_FLAGS="-g"
+COMPILER_FLAGS="-Wall -Wextra -pedantic -g"
 IFLAGS=$(find . -name "*.h" | xargs dirname | uniq | awk '{ print "-I" $0 }')
 
 SRC_FILES=$(find . -name "*.c")


### PR DESCRIPTION
Fixes #1 

* Add compiler flags `-Wall -Wextra -pedantic`
* Fix compiler warnings
* Bug fix. `ftell` returns `-1` on errors which is stored in a unsigned variable.

> "...ftell() returns the current offset.  Otherwise, -1 is returned and errno is set to indicate the error."
man page for ftell (`man 3 ftell`)
https://linux.die.net/man/3/ftell